### PR TITLE
Use Bun and not NPM with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,16 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
-  "enabledManagers": ["github-actions", "npm"],
+  "enabledManagers": ["bun", "github-actions"],
   "packageRules": [
     {
-      "groupName": "gh minor",
-      "matchManagers": ["github-actions"],
+      "groupName": "bun minor",
+      "matchManagers": ["bun"],
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
-      "groupName": "npm minor",
-      "matchManagers": ["npm"],
+      "groupName": "gh minor",
+      "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ]


### PR DESCRIPTION
## 🎟️ Tracking

Internal change.

## 📔 Objective

This repository uses [Bun](https://docs.renovatebot.com/modules/manager/bun/), so configure Renovate to use that instead of NPM.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
