### PR TITLE
fix: remove table separators between login and mfa tags in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ This is a living list. If you are aware of other solutions, websites or platform
 | ![logo](/public/logos/qapital.svg) | Qapital | [qapital.com](https://qapital.com/) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/robinhood.svg) | Robinhood | [robinhood.com/login](https://robinhood.com/login) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/roblox.svg) | Roblox | [roblox.com/login](https://roblox.com/login) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/salesforce.svg) | Salesforce | [help.salesforce.com](https://help.salesforce.com/s/articleView?id=sf.use_built_in_authenticators_as_a_verification_method.htm&type=5) | ![Login](/public/tags/login.svg "Login") | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/salesforce.svg) | Salesforce | [help.salesforce.com](https://help.salesforce.com/s/articleView?id=sf.use_built_in_authenticators_as_a_verification_method.htm&type=5) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/samsung.svg) | Samsung | [samsung.com](https://www.samsung.com/uk/support/apps-services/how-to-create-and-use-a-passkey/) | ![Login](/public/tags/login.svg "Login") | ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/shop.svg) | Shop Pay | [shop.app](https://shop.app) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/shopify.svg) | Shopify | [accounts.shopify.com/lookup](https://accounts.shopify.com/lookup) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/playstation.svg) | Sony Playstation | [www.playstation.com](https://www.playstation.com/en-us/passkey/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/stripe.svg) | Stripe | [support.stripe.com](https://support.stripe.com/questions/set-up-a-passkey-for-one-click-login) | ![Login](/public/tags/login.svg "Login") | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/stripe.svg) | Stripe | [support.stripe.com](https://support.stripe.com/questions/set-up-a-passkey-for-one-click-login) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/synology.svg) | Synology DSM | [www.synology.com/en-global/dsm](https://www.synology.com/en-global/dsm) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/tailscale.svg) | Tailscale | [tailscale.com](https://tailscale.com/) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/tender.svg) | Tender | [tender.run](https://tender.run/) | ![Login](/public/tags/login.svg "Login") |


### PR DESCRIPTION
Removes unwanted markdown table separators between login and mfa tags in readme.md. For example, MFA is supported for Salesforce as shown in the readme.md but not shown on the website.