### PR TITLE
 Add missing passkey entries from 1Password (deduplicated & sorted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,114 +32,296 @@ This is a living list. If you are aware of other solutions, websites or platform
 | --- | --- | --- | ---: |
 | ![logo](/public/logos/0pass.svg) | 0pass | [0pass.com](https://0pass.com/) | ![Login](/public/tags/login.svg "Login") | 
 | ![logo](/public/logos/abanca.svg) | ABANCA | [comunicacion.abanca.com](https://comunicacion.abanca.com/es/noticias/abanca-primer-banco-espanol-en-implantar-la-tecnologia-de-llaves-de-acceso-en-la-banca-movil-para-reforzar-la-seguridad-de-sus-clientes/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/adobe.svg) | Adobe | [adobe.com](https://adobe.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/adobe.svg) | Adobe | [account.adobe.com/login](https://account.adobe.com/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/aflac.svg) | Aflac Japan | [www.aflac.co.jp](https://www.aflac.co.jp/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/afasonline.svg) | AFAS | [afasonline.nl](https://afasonline.nl) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/affirm.svg) | Affirm | [affirm.com](https://affirm.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/affirm.svg) | Affirm | [helpcenter.affirm.com](https://helpcenter.affirm.com/s/article/Set-up-a-Passkey) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/aflac.svg) | Aflac Japan | [www.aflac.co.jp](https://www.aflac.co.jp/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/airnewzealand.svg) | Air New Zealand | [airnewzealand.co.nz](https://airnewzealand.co.nz) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/air-new-zealand.svg) | Air New Zealand | [www.airnewzealand.com](https://www.airnewzealand.com/manage-multi-factor-authentication#passkeys) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
-| ![logo](/public/logos/amazon.svg) | Amazon | [www.amazon.com](https://www.amazon.com/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/arpari.svg) | Arpari | [app.arpari.com/login](https://app.arpari.com/login) | ![Login](/public/tags/login.svg "Login") | 
-| ![logo](/public/logos/authgear.svg)| Authgear | [accounts.portal.authgearapps.com/login](https://accounts.portal.authgearapps.com/login) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/authentik.svg)| authentik | [docs.goauthentik.io](https://docs.goauthentik.io/docs/flow/stages/authenticator_validate/#passwordless-authentication) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/ah.svg) | Albert Heijn | [ah.nl](https://ah.nl) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/amazon.svg) | Amazon | [amazon.com](https://amazon.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/aws.svg)| Amazon Web Services (AWS) | [aws.amazon.com](https://aws.amazon.com/iam/features/mfa/?audit=2019q1) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/best-buy.svg) | Best Buy | [www.bestbuy.com/identity/signin](https://www.bestbuy.com/identity/signin) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/forums.svg) | Anki Forums | [forums.ankiweb.net](https://forums.ankiweb.net) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/apple.svg) | Apple | [apple.com](https://apple.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/arbeitsagentur.svg) | Arbeitsagentur | [arbeitsagentur.de](https://arbeitsagentur.de) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/arca.svg) | Arcalive | [arca.live](https://arca.live) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/armstrong.svg) | Armstrong Bank | [armstrong.bank](https://armstrong.bank) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/arpari.svg) | Arpari | [arpari.com](https://arpari.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/arpari.svg) | Arpari | [app.arpari.com/login](https://app.arpari.com/login) | ![Login](/public/tags/login.svg "Login") | 
+| ![logo](/public/logos/id.svg) | au | [id.auone.jp](https://id.auone.jp) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/authentik.svg)| authentik | [docs.goauthentik.io](https://docs.goauthentik.io/docs/flow/stages/authenticator_validate/#passwordless-authentication) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/authgear.svg) | Authgear | [authgear.com](https://authgear.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/authgear.svg)| Authgear | [accounts.portal.authgearapps.com/login](https://accounts.portal.authgearapps.com/login) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/authsignal.svg) | Authsignal | [authsignal.com](https://authsignal.com) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/bagou450.svg) | Bagou450 | [bagou450.com](https://bagou450.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/bestbuy.svg) | Best Buy | [bestbuy.com](https://bestbuy.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/beyondidentity.svg) | Beyond Identity | [beyondidentity.com](https://beyondidentity.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/beyond-identity.svg) | Beyond Identity | [console-us.beyondidentity.com/signup](https://console-us.beyondidentity.com/signup) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/binance.svg) | Binance | [www.binance.com](https://www.binance.com/en/support/faq/how-to-create-a-passkey-for-my-binance-account-2aec8fe0437242f2a5fbef9cdb71d4c2) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/binance.svg) | Binance | [binance.com](https://binance.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/bitbank.svg) | bitbank | [bitbank.cc](https://support.bitbank.cc/hc/ja/articles/33591659742745-%E7%94%9F%E4%BD%93%E8%AA%8D%E8%A8%BC%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%9F%E3%81%84) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/bitwarden.svg) | Bitwarden | [bitwarden.com](https://bitwarden.com) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/community.svg) | Bitwarden Community Forums | [community.bitwarden.com](https://community.bitwarden.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/blue-ocean-law.svg) | Blue Ocean Law | [www.blueocean.law](https://www.blueocean.law/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/bmw.svg) | BMW | [bmw.com](https://bmw.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/bmw.svg) | BMW | [mybmw.bmwusa.com](https://mybmw.bmwusa.com/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/bolt.svg) | Bolt | [bolt.eu](https://bolt.eu) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/boursobank.svg) | Bourseroma | [www.boursorama.com](https://www.boursorama.com/) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/boursobank.svg) | BoursoBank | [clients.boursobank.com](https://clients.boursobank.com/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/boursorama.svg) | Boursorama | [boursorama.com](https://boursorama.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/braun.svg) | Braunhousehold | [braunhousehold.com](https://braunhousehold.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/breadfinancial.svg) | Bread Financial | [breadfinancial.com](https://breadfinancial.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/bridgecrest.svg) | Bridgecrest | [bridgecrest.com](https://bridgecrest.com) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/cape-cod-5.svg) | Cape Cod 5 | [www.capecodfive.com](https://www.capecodfive.com/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/canva.svg) | Canva | [canva.com](https://canva.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/capecodfive.svg) | Cape Cod 5 | [capecodfive.com](https://capecodfive.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/card-pointers.svg) | Card Pointers | [cardpointers.com/login](https://cardpointers.com/login/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/cardpointers.svg) | CardPointers | [cardpointers.com](https://cardpointers.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/caremark.svg) | Caremark | [caremark.com](https://caremark.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/carnival.svg) | Carnival | [carnival.com](https://carnival.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/cash.svg) | Cash App | [cash.app](https://cash.app) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/chekspend.svg) | Chek | [chekspend.com](https://chekspend.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/citibank.svg) | Citibank | [www.citi.com](https://www.citi.com/) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/citrix.svg) | Citrix | [docs.citrix.com/en-us/citrix-workspace-app-for-linux](https://docs.citrix.com/en-us/citrix-workspace-app-for-linux/authentication.html) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/cloudflare.svg) | Cloudflare | [developers.cloudflare.com](https://developers.cloudflare.com/fundamentals/setup/account/account-security/2fa/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/cloze.svg) | Cloze | [cloze.com](https://cloze.com) | ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/coinbase.svg) | Coinbase | [www.coinbase.com](https://www.coinbase.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/computerbase.svg) | ComputerBase | [computerbase.de](https://computerbase.de) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/corbado.svg) | Corbado | [corbado.com](https://corbado.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/corbado.svg) | Corbado | [app.corbado.com/signin](https://app.corbado.com/signin) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/coveto.svg) | Coveto Recruiting Software | [coveto.de](https://coveto.de) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/cutx.svg) | Credit Union of Texas | [cutx.org](https://cutx.org) | ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/credit-union-of-texas.svg) | Credit Union of Texas | [online.cutx.org](https://online.cutx.org/settings/security) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/crowdin.svg) | Crowdin | [crowdin.com](https://crowdin.com) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/crownaudit.svg) | Crown Audit | [crownaudit.org](https://crownaudit.org) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/mycurricula.svg) | Curricula | [mycurricula.com](https://mycurricula.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/customerping.svg) | CustomerPing.AI | [customerping.ai](https://customerping.ai) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/cvs.svg) | CVS | [www.cvs.com](https://www.cvs.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/cvs.svg) | CVS Caremark | [www.caremark.com](https://www.caremark.com/digital-fast/caremark-login-web/#/login) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/cvsspecialty.svg) | CVS Specialty | [cvsspecialty.com](https://cvsspecialty.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/cyberark.svg) | CyberArk Identity | [docs.cyberark.com/](https://docs.cyberark.com/identity/Latest/en/Content/UserPortal/user-setup-passkey.htm?tocpath=End%20User%7CSet%20up%20authentication%7C_____6) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
-| ![logo](/public/logos/daylite.svg) | Daylite | [www.marketcircle.com/account/login](https://www.marketcircle.com/account/login) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/datapacket.svg) | DataPacket | [datapacket.com](https://datapacket.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/marketcircle.svg) | Daylite | [marketcircle.com](https://marketcircle.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/passkeys.svg) | Descope passkeys demo | [passkeys.guru](https://passkeys.guru) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/telekom.svg) | Deutsche Telekom | [telekom.de](https://telekom.de) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/devolutions.svg) | Devolutions | [devolutions.com](https://devolutions.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/dext.svg) | DEXT | [dext.com](https://dext.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/dinero.svg) | Dinero | [dinero.dk](https://dinero.dk) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/discord.svg) | Discord | [discord.com/blog](https://discord.com/blog/how-discord-modernized-mfa-with-webauthn) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/discourse.svg) | Discourse | [discourse.org](https://discourse.org) | ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/discourse.svg) | Discourse | [meta.discourse.org](https://meta.discourse.org/t/support-passwordless-login-with-passkeys) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/id.svg) | Docomo | [id.smt.docomo.ne.jp](https://id.smt.docomo.ne.jp) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/docomo.svg) | Docomo | [www.docomo.ne.jp/english](https://www.docomo.ne.jp/english/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/documenso.svg) | Documenso | [documenso.com](https://documenso.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/docusign.svg) | DocuSign | [docusign.com](https://docusign.com) | ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/docusign.svg) | DocuSign | [account.docusign.com](https://account.docusign.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/dropbox.svg) | Dropbox | [help.dropbox.com](https://help.dropbox.com/account-access/enable-two-step-verification#securitykey) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/duke.svg) | Duke | [duke.edu](https://duke.edu) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/ebay.svg) | eBay | [ebay.com](https://ebay.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/ebay.svg) | eBay | [signin.ebay.com/ws/eBayISAPI.dll](https://signin.ebay.com/ws/eBayISAPI.dll) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/ee.svg) | EE | [ee.co.uk](https://ee.co.uk) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/ente.svg) | ente | [ente.io](https://ente.io/blog/introducing-passkeys-on-ente/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/eslgaming.svg) | Esl Gaming | [eslgaming.com](https://eslgaming.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/facebook.svg) | Facebook | [facebook.com/help](https://www.facebook.com/help/1181045243159511/?helpref=uf_share) | ![Login](/public/tags/login.svg) |
+| ![logo](/public/logos/fairfaxcounty.svg) | Fairfax County, Virginia (MyFairfax) | [fairfaxcounty.gov](https://fairfaxcounty.gov) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/fastmail.svg) | Fastmail | [fastmail.com](https://fastmail.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/fastmail.svg) | Fastmail | [app.fastmail.com](https://app.fastmail.com/settings/security/passkeys) | ![Login](/public/tags/login.svg) ![MFA](/public/tags/mfa.svg) |
+| ![logo](/public/logos/finom.svg) | Finom | [finom.co](https://finom.co) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/fintual.svg) | Fintual | [fintual.cl](https://fintual.cl) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/secure.svg) | First Financial Bank | [secure.bankatfirst.com](https://secure.bankatfirst.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/fleeps.svg) | fleeps | [fleeps.co](https://fleeps.co/) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/forgejo.svg) | Forgejo | [forgejo.org](https://forgejo.org/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/formx.svg) | FormX.ai | [formx.ai](https://formx.ai) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/form-x-ai.svg) | FormX.ai | [auth.formextractorai.com/login](https://auth.formextractorai.com/login) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/forwardemail.svg) | ForwardEmail | [forwardemail.net](https://forwardemail.net) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/freetaxusa.svg) | Free Tax USA | [freetaxusa.com](https://freetaxusa.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/freeprints.svg) | FreePrints | [freeprints.com](https://freeprints.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/fusionauth.svg) | FusionAuth | [fusionauth.io](https://fusionauth.io) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/gemini.svg) | Gemini | [support.gemini.com](https://support.gemini.com/hc/en-us/articles/17421039737243-What-are-passkeys) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/gemini.svg) | Gemini Exchange | [gemini.com](https://gemini.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/gitea.svg) | Gitea | [docs.gitea.com](https://docs.gitea.com/usage/multi-factor-authentication) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/github.svg) | GitHub | [github.com](https://github.com) | ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/github.svg) | GitHub | [docs.github.com](https://docs.github.com/en/authentication/authenticating-with-a-passkey/signing-in-with-a-passkey) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/gitlab.svg) | GitLab | [docs.gitlab.com](https://docs.gitlab.com/ee/user/profile/account/two_factor_authentication.html) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
-| ![logo](/public/logos/gitea.svg) | Gitea | [docs.gitea.com](https://docs.gitea.com/usage/multi-factor-authentication) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/glauca.svg) | Glauca Digital | [glauca.digital](https://glauca.digital) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/godaddy.svg) | GoDaddy | [sso.godaddy.com](https://sso.godaddy.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/google.svg) | Google | [www.google.com](https://www.google.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/grab.svg) | Grab (App) | [grab.com](https://grab.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/haeppie.svg) | haeppie | [haeppie.com](https://haeppie.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/haeppie.svg) | haeppie | [be.haeppie.com/auth](https://be.haeppie.com/auth) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/hancock.svg) | Hancock | [hancock.ink](https://hancock.ink) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/hancock.svg) | Hancock.ink | [idp.hancock.ink](https://idp.hancock.ink/v0) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/hanko.svg) | Hanko | [cloud.hanko.io/login](https://cloud.hanko.io/login) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/home-depot.svg) | Home Depot | [www.homedepot.com](https://www.homedepot.com/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/horizon-pics.svg) | Horizon Pics | [horizon.pics](https://horizon.pics) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/hanko.svg) | Hanko.io | [hanko.io](https://hanko.io) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/hardwax.svg) | Hard Wax | [hardwax.com](https://hardwax.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/hatena.svg) | Hatena | [hatena.ne.jp](https://hatena.ne.jp) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/hcaptcha.svg) | hCaptcha | [hcaptcha.com](https://hcaptcha.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/heexy.svg) | Heexy | [heexy.org](https://heexy.org) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/high-mobility.svg) | High Mobility | [high-mobility.com](https://high-mobility.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/community.svg) | Home Assistant | [community.home-assistant.io](https://community.home-assistant.io) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/homedepot.svg) | Home Depot | [homedepot.com](https://homedepot.com) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/horizon.svg) | Horizon Pics | [horizon.pics](https://horizon.pics) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/hubspot.svg) | Hubspot | [hubspot.com](https://hubspot.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/ibm.svg) | IBM Verify | [www.ibm.com/docs](https://www.ibm.com/docs/en/security-verify?topic=launchpad-managing-your-verify-authenticators) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/icloud.svg) | iCloud | [icloud.com](https://icloud.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/imo.svg) | imo | [imo.im](https://imo.im/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/instacart.svg) | Instacart | [www.instacart.com](https://www.instacart.com/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/kayak.svg) | Kayak | [www.kayak.com](https://www.kayak.com/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/indeed.svg) | Indeed | [indeed.com](https://indeed.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/instacart.svg) | Instacart | [instacart.com](https://instacart.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/intastellaraccounts.svg) | Intastellar Accounts | [intastellaraccounts.com](https://intastellaraccounts.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/kakaocorp.svg) | Kakao | [kakaocorp.com](https://kakaocorp.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/kit.svg) | Karlsruhe Institute of Technology (KIT) | [kit.edu](https://kit.edu) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/kayak.svg) | KAYAK | [kayak.com](https://kayak.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/kemba.svg) | KEMBA Financial Credit Union | [my.kemba.org](https://my.kemba.org/settings/security) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/kenwood.svg) | Kenwoodworld.com | [kenwoodworld.com](https://kenwoodworld.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/klemn.svg) | Klemn | [klemn.net](https://klemn.net) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/kraken.svg) | Kraken | [kraken.com](https://support.kraken.com/hc/en-us/articles/what-is-a-passkey) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/laakari-chat.svg) | Laakari.chat | [laakari.chat](https://laakari.chat) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/linkedin.svg) | LinkedIn | [linkedin.com](https://www.linkedin.com/help/linkedin/answer/a1621596) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/lnk-bio.svg) | Lnk.Bio | [lnk.bio](https://lnk.bio/linkin/log-in-with-passkeys-to-lnkbio) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/larksuite.svg) | larksuite.com | [larksuite.com](https://larksuite.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/forum.svg) | Level1Techs Forum | [forum.level1techs.com](https://forum.level1techs.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/lgtm.svg) | LGTM.lol | [lgtm.lol](https://lgtm.lol) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/linear.svg) | Linear | [linear.app](https://linear.app) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/link.svg) | Link by Stripe | [link.com](https://link.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/link3.svg) | Link3 | [link3.to](https://link3.to) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/linkedin.svg) | LinkedIn | [linkedin.com](https://linkedin.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/live.svg) | live.com | [live.com](https://live.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/lnk.svg) | lnk.bio | [lnk.bio](https://lnk.bio) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/locker.svg) | Locker | [locker.io](https://locker.io) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/login-gov.svg) | Login.gov | [login.gov](https://login.gov/help/get-started/authentication-methods/#security-key) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/lowes.svg) | Lowe's | [lowes.com](https://lowes.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/luno.svg) | Luno | [luno.com](https://luno.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/luxid.svg) | LuxID | [luxid.lu](https://luxid.lu) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/mangadex.svg) | Mangadex | [mangadex.org](https://mangadex.org/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/marshmallow-qa.svg) | Marshmallow | [marshmallow-qa.com](https://marshmallow-qa.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/marshmallow-qa.svg) | Marshmallow-qa\.com | [diverdown.wraptas.site](https://diverdown.wraptas.site/3ec9bbfd244d41149909d1cd5f8003ec) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/jp.svg) | Mercari | [jp.mercari.com](https://jp.mercari.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/mercari.svg) | Mercari | [engineering.mercari.com](https://engineering.mercari.com/en/blog/entry/20230810-mercaris-passkey-adoption/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/microcenter.svg) | Micro Center | [microcenter.com](https://microcenter.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/microsoft.svg) | Microsoft | [microsoft.com](https://microsoft.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
-| ![logo](/public/logos/money-forward.svg) | Money Forward ID | [id.moneyforward.com/sign_in](https://id.moneyforward.com/sign_in) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/entra.svg) | Microsoft Entra ID | [entra.microsoft.com](https://entra.microsoft.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/migros.svg) | Migros | [migros.ch](https://migros.ch) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/mini.svg) | MINI | [mini.com](https://mini.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/reader.svg) | Miniflux | [reader.miniflux.app](https://reader.miniflux.app) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/wallet.svg) | Mintbase Wallet | [wallet.mintbase.xyz](https://wallet.mintbase.xyz) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/minter.svg) | minter.io | [minter.io](https://minter.io) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/m.svg) | MIXI M | [m.mixi.com](https://m.mixi.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/id.svg) | Money Forward ID | [id.moneyforward.com](https://id.moneyforward.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/moneybird.svg) | Moneybird | [moneybird.com](https://moneybird.com) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/helsana.svg) | My Helsana (App only) | [helsana.ch](https://helsana.ch) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/my.svg) | My KONAMI | [my.konami.net](https://my.konami.net) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/my.svg) | MyGov AU | [my.gov.au](https://my.gov.au) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/mysites.svg) | mySites.guru | [mysites.guru](https://mysites.guru) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/namecheap.svg) | Namecheap | [www.namecheap.com](https://www.namecheap.com/support/knowledgebase/article.aspx/10102/45/how-can-i-use-the-u2f-method-for-twofactor-authentication/) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/netfiles.svg) | netfiles | [netfiles.com](https://netfiles.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/netfiles.svg) | netfiles | [www.netfiles.com](https://help.netfiles.de/en/creating-a-passkey-for-netfiles/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/nintendo.svg) | Nintendo | [www.nintendo.com](https://www.nintendo.com/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/nhs.svg) | NHS | [nhs.uk](https://nhs.uk) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/nintendo.svg) | Nintendo | [nintendo.com](https://nintendo.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/notion.svg) | Notion | [notion.so](https://notion.so) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/apps.svg) | nulab | [apps.nulab.com](https://apps.nulab.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/nvidia.svg) | Nvidia | [nvidia.com](https://nvidia.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/okta.svg) | Okta | [okta.com](https://okta.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
-| ![logo](/public/logos/omglol.svg) | omg.lol | [omg.lol](https://omg.lol) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/pastery.svg) | Pastery | [pastry.net](https://pastery.net/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/paypal.svg) | PayPal | [www.paypal.com/signin](https://www.paypal.com/signin/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/okx.svg) | OKX | [okx.com](https://okx.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/omg.svg) | omg.lol | [omg.lol](https://omg.lol) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/onedrive.svg) | Onedrive | [onedrive.com](https://onedrive.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/onelog.svg) | OneLog | [onelog.ch](https://onelog.ch) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/onlinescoutmanager.svg) | Online Scout Manager (OSM) | [onlinescoutmanager.co.uk](https://onlinescoutmanager.co.uk) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/onlyfans.svg) | OnlyFans | [onlyfans.com](https://onlyfans.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/outlook.svg) | Outlook Mail | [outlook.com](https://outlook.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/Paidy.svg) | Paidy (iOS/Android Apps) | [Paidy.com](https://Paidy.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/papermark.svg) | Papermark | [papermark.io](https://papermark.io) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/passage.svg) | Passage | [passage.id](https://passage.id) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/passage.svg) | Passage Authentication Demo | [passage.1password.com](https://passage.1password.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/pastery.svg) | Pastery | [pastery.net](https://pastery.net) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/payfit.svg) | PayFit | [payfit.com](https://payfit.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/paypal.svg) | PayPal | [paypal.com](https://paypal.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/pixiv.svg) | Pixiv | [pixiv.net](https://pixiv.net) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/playstation.svg) | PlayStation | [playstation.com](https://playstation.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/poblano.svg) | Poblano | [poblano.jp](https://poblano.jp) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/poloniex.svg) | Poloniex | [poloniex.com](https://poloniex.com) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/porkbun.svg) | Porkbun | [porkbun.com](https://porkbun.com) | ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/porkbun.svg) | porkbun | [kb.porkbun.com](https://kb.porkbun.com/article/119-how-to-secure-your-account-with-a-physical-security-key-using-webauthn) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/practiceprotect.svg) | Practice Protect | [practiceprotect.com](https://practiceprotect.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/getprismm.svg) | Prismm | [getprismm.com](https://getprismm.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/qapital.svg) | Qapital | [qapital.com](https://qapital.com/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/robinhood.svg) | Robinhood | [robinhood.com/login](https://robinhood.com/login) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/roblox.svg) | Roblox | [roblox.com/login](https://roblox.com/login) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/rad.svg) | rad.dad | [rad.dad](https://rad.dad) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/ring.svg) | Ring | [ring.com](https://ring.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/robinhood.svg) | Robinhood | [robinhood.com](https://robinhood.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/roblox.svg) | Roblox | [roblox.com](https://roblox.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/salad.svg) | Salad | [salad.com](https://salad.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/salesforce.svg) | Salesforce | [help.salesforce.com](https://help.salesforce.com/s/articleView?id=sf.use_built_in_authenticators_as_a_verification_method.htm&type=5) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/samsung.svg) | Samsung | [samsung.com](https://www.samsung.com/uk/support/apps-services/how-to-create-and-use-a-passkey/) | ![Login](/public/tags/login.svg "Login") | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/scrooge.svg) | Scrooge Games | [scrooge.games](https://scrooge.games) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/shakepay.svg) | Shakepay | [shakepay.com](https://shakepay.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/shop.svg) | Shop Pay | [shop.app](https://shop.app) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/shopify.svg) | Shopify | [shopify.com](https://shopify.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/shopify.svg) | Shopify | [accounts.shopify.com/lookup](https://accounts.shopify.com/lookup) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/simply.svg) | Simply.com | [simply.com](https://simply.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/siriusxm.svg) | Sirius XM Satellite Radio | [siriusxm.com](https://siriusxm.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/sktelecom.svg) | SK Telecom | [sktelecom.com](https://sktelecom.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/passkey.svg) | SK Telecom passkey demo | [passkey.sktelecom.com](https://passkey.sktelecom.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/snapchat.svg) | Snapchat | [snapchat.com](https://snapchat.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/so-net.svg) | So-net | [so-net.ne.jp](https://so-net.ne.jp) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/sony.svg) | Sony | [sony.com](https://sony.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/playstation.svg) | Sony Playstation | [www.playstation.com](https://www.playstation.com/en-us/passkey/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/spaceship.svg) | Spaceship (by NameCheap) | [spaceship.com](https://spaceship.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/squareup.svg) | Square | [squareup.com](https://squareup.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/stall-frei.svg) | Stall-Frei.de | [stall-frei.de](https://stall-frei.de) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/michigan.svg) | State of Michigan | [michigan.gov](https://michigan.gov) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/station-drivers.svg) | Station-Drivers | [station-drivers.com](https://station-drivers.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/stripe.svg) | Stripe | [stripe.com](https://stripe.com) | ![MFA](/public/tags/mfa.svg "MFA") |
 | ![logo](/public/logos/stripe.svg) | Stripe | [support.stripe.com](https://support.stripe.com/questions/set-up-a-passkey-for-one-click-login) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/ope.svg) | Stuudium | [ope.ee](https://ope.ee) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/sumup.svg) | SumUp | [sumup.com](https://sumup.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/swica.svg) | Swica | [swica.ch](https://swica.ch) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/eduid.svg) | SWITCH edu-ID | [eduid.ch](https://eduid.ch) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/syncfusion.svg) | Syncfusion | [syncfusion.com](https://syncfusion.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/synology.svg) | Synology | [synology.com](https://synology.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/synology.svg) | Synology DSM | [www.synology.com/en-global/dsm](https://www.synology.com/en-global/dsm) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/tailscale.svg) | Tailscale | [tailscale.com](https://tailscale.com/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/tender.svg) | Tender | [tender.run](https://tender.run/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/tailscale.svg) | Tailscale | [tailscale.com](https://tailscale.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/target.svg) | Target | [target.com](https://target.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/techbookfest.svg) | techbookfest | [techbookfest.org](https://techbookfest.org) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/telstra.svg) | Telstra | [telstra.com](https://telstra.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/tender.svg) | Tender | [tender.run](https://tender.run) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/thehendrixjc.svg) | The Hendrix | [thehendrixjc.com](https://thehendrixjc.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/thunder.svg) | Thunder | [thunder.gg](https://thunder.gg) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/tiaa.svg) | TIAA | [tiaa.org](https://tiaa.org) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/ticketeer.svg) | Ticketeer | [ticketeer.se](https://ticketeer.se) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/tiktok.svg) | TikTok | [tiktok.com](https://newsroom.tiktok.com/en-us/passkeys-fido-alliance) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/the-hendrix.svg) | The Hendrix | [thehendrixjc.com](https://thehendrixjc.com/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/trusona.svg) | Trusona Authentication Cloud | [trusona.com](http://trusona.com/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/uber.svg) | Uber | [www.uber.com](https://www.uber.com/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/id.svg) | TOKYU | [id.tokyu.co.jp](https://id.tokyu.co.jp) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/trimble.svg) | Trimble | [trimble.com](https://trimble.com) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/tripletex.svg) | Tripletex | [tripletex.no](https://tripletex.no) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/trusona.svg) | Trusona Authentication Cloud | [trusona.com](https://trusona.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/trustworthy.svg) | Trustworthy | [trustworthy.com](https://trustworthy.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/turnkey.svg) | Turnkey | [turnkey.com](https://turnkey.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/twitter.svg) | Twitter | [twitter.com](https://twitter.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/ubank.svg) | Ubank | [ubank.com.au](https://ubank.com.au) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/uber.svg) | Uber | [uber.com](https://uber.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/ulys.svg) | Ulys | [ulys.com](https://ulys.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/app.svg) | Uninbox | [app.uninbox.com](https://app.uninbox.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/usfcu.svg) | United Southeast Federal Credit Union | [usfcu.org](https://usfcu.org) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/usesarchbtw.svg) | usesarchbtw.lol | [usesarchbtw.lol](https://usesarchbtw.lol) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/vault-vision.svg) | Vault Vision | [vaultvision.com](https://vaultvision.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
-| ![logo](/public/logos/vercel.svg) | Vercel | [vercel.com](https://vercel.com/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/vercel.svg) | Vercel | [vercel.com](https://vercel.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/virgin-media.svg) | Virgin Media | [virginmedia.com](https://virginmedia.com/) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/home.svg) | Visma | [home.visma.com](https://home.visma.com) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/vk.svg) | vk | [vk.com](https://vk.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/voura.svg) | Voura | [voura.com](https://voura.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/walmart.svg) | Walmart | [walmart.com](https://walmart.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/webauthn.svg) | WebAuthn.io | [webauthn.io](https://webauthn.io) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/webauthn.svg) | WebAuthn\.io | [webauthn.io](https://webauthn.io/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/hyatt.svg) | World of Hyatt | [hyatt.com](https://hyatt.com/) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/x.svg) | X (formerly Twitter) | [help.x.com](https://help.x.com/en/managing-your-account/how-to-use-passkey) | ![Login](/public/tags/login.svg "Login") |
-| ![logo](/public/logos/yahoo.svg) | Yahoo! | [www.yahoo.com](https://www.yahoo.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
-| ![logo](/public/logos/zoho.svg) | Zoho | [zoho.com](http://zoho.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
-| ![logo](/public/logos/walmart.svg) | Walmart | [walmart.com/help](https://www.walmart.com/help/article/passkeys/79bc4a57374146c497ebe3bf8d4f9b10) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/webull.svg) | Webull | [webull.com.au](https://webull.com.au) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/wellsfargo.svg) | Wells Fargo | [wellsfargo.com](https://wellsfargo.com) | ![Login](/public/tags/login.svg "Login") |
 | ![logo](/public/logos/whatsapp.svg) | WhatsApp | [whatsapp.com](https://faq.whatsapp.com/1850567238795036/?cms_platform=android&helpref=platform_switcher) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/whatsapp.svg) | WhatsApp (iOS and Android) | [whatsapp.com](https://whatsapp.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/hyatt.svg) | World of Hyatt | [hyatt.com](https://hyatt.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/x.svg) | X (formerly Twitter) | [help.x.com](https://help.x.com/en/managing-your-account/how-to-use-passkey) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/x.svg) | X (Twitter) iOS | [x.com](https://x.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/xenforo.svg) | XenForo (Community) | [xenforo.com/community](https://xenforo.com/community) | ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/mail.svg) | Yahoo mail | [mail.yahoo.com](https://mail.yahoo.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/yahoo.svg) | Yahoo! | [www.yahoo.com](https://www.yahoo.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
+| ![logo](/public/logos/yahoo.svg) | Yahoo! JAPAN | [yahoo.co.jp](https://yahoo.co.jp) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/yandex.svg) | Yandex | [yandex.ru](https://yandex.ru) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/zitadel.svg) | Zitadel | [zitadel.com](https://zitadel.com) | ![Login](/public/tags/login.svg "Login") |
+| ![logo](/public/logos/zoho.svg) | Zoho | [zoho.com](https://zoho.com/) | ![Login](/public/tags/login.svg "Login") ![MFA](/public/tags/mfa.svg "MFA") |
 
 ### **Developer tools** {#developer-tools}
 


### PR DESCRIPTION
preface: First time doing this so please go gentle. I am a Network Engineer.
I saw some videos on Bitwarden and passkeys and hoping to contribute to the cause.
I used to use 1Password as well.
Also got some chatGPT support.

Description:

This update adds missing passkey-supported services pulled from [passkeys.directory (1Password)](https://passkeys.directory/), after comparing with the current Bitwarden list.
✅ Summary of changes:

    Added entries missing from Bitwarden but listed in 1Password.

    Entries deduplicated (e.g. merged Login+MFA if already partially listed).

    Sorted alphabetically by service name.

    Logo references included using /public/logos/*.svg, but some logo files may still be missing and will be handled in a future update.